### PR TITLE
1.21 Support (JDK 21)

### DIFF
--- a/.changeset/cuddly-beers-repeat.md
+++ b/.changeset/cuddly-beers-repeat.md
@@ -1,0 +1,5 @@
+---
+'@yam-js/plugin': minor
+---
+
+1.21 Support (JDK 21)

--- a/packages/yamjs-plugin/common/src/main/java/yamjs/Config.java
+++ b/packages/yamjs-plugin/common/src/main/java/yamjs/Config.java
@@ -16,7 +16,7 @@ public class Config {
    public String pluginName = "YamJS";
 
    /**
-    * This property determines whether or not the JavaScript initialization
+    * This property determines whether the JavaScript initialization
     * function should be called.
     */
    public boolean initialize = true;

--- a/packages/yamjs-plugin/gradle.properties
+++ b/packages/yamjs-plugin/gradle.properties
@@ -1,2 +1,2 @@
 # GraalJS Version
-graalVersion=22.3.1
+graalVersion=23.0.4

--- a/packages/yamjs-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/yamjs-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/yamjs-plugin/package.json
+++ b/packages/yamjs-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yam-js/plugin",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.4",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/yamjs-plugin/package.json
+++ b/packages/yamjs-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yam-js/plugin",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/yamjs-plugin/paper/build.gradle
+++ b/packages/yamjs-plugin/paper/build.gradle
@@ -20,7 +20,7 @@ dependencies {
    implementation "org.graalvm.truffle:truffle-api:${graalVersion}"
 
    // platform-specific deps
-   compileOnly "org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT"
+   compileOnly "org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT"
 }
 
 jar {


### PR DESCRIPTION
Bumps…
- GraalJS -> 23.0.4
- Gradle -> 8.8
- Spigot -> 1.21-R0.1

Addresses #46 (and grammar)

Thank you

Also, alliterating [Spigot](https://www.spigotmc.org/threads/spigot-bungeecord-1-21.650824/), "Mojang has decided to make Minecraft 1.21 require Java 21 or later." So yea